### PR TITLE
simplify the parse final results parameter

### DIFF
--- a/src/ParserInterface.js
+++ b/src/ParserInterface.js
@@ -224,26 +224,23 @@ class ParserInterface {
   }
 
   //TODO: Typescript
-  //rolls: [ { rolls: DiceBoxResult[] } ]
+  //rolls: DiceBoxResult[]
   updateFloats(rolls) {
     rolls.forEach((roll) => {
-      return Object.entries(roll).forEach(([key, die]) => {
-        const sides = die.sides;
-        this.rollsAsFloats.push((die.value - 1) / sides);
-      });
+      this.rollsAsFloats.push((roll.value - 1) / roll.sides);
     });
   }
 
   //TODO: Typescript
-  //rollResults: { rolls: DiceBoxResult[] }
+  //rollResults: DiceBoxResult[]
   //rolls: DiceBoxResult[]
   //finalResults: RollTypeResult
   //this.rollsAsFloats = undefined;
   parseFinalResults(rollResults = []) {
     // do the final parse
-    const rolls = this.recursiveSearch(rollResults, "rolls");
+    //const rolls = this.recursiveSearch(rollResults, "rolls");
 
-    this.updateFloats(rolls);
+    this.updateFloats(rollResults);
 
     const finalResults = this.rollParser.rollParsed(this.parsedNotation);
 

--- a/src/ParserInterface.test.js
+++ b/src/ParserInterface.test.js
@@ -17,7 +17,7 @@ describe("Given new ParserInterface is created", () => {
 
 describe("Given new ParserInterface is created after rollsAsFloats has been updated", () => {
   const parser = new ParserInterface();
-  parser.updateFloats([ReturnDiceBoxRoll]);
+  parser.updateFloats(ReturnDiceBoxRoll);
 
   describe("when initParser runs AND updateFloats has been called", () => {
     it("then has rollsAsFloats set to number[]", () => {

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -4,24 +4,22 @@ export const ReturnDiceBoxRoll = [
   { groupId: 0, rollId: 1, sides: 20, theme: "#FFFFFF", value: 11 },
 ];
 
-export const ParameterParseFinalResults = {
-  rolls: [
-    {
-      groupId: 0,
-      rollId: 0,
-      sides: 20,
-      theme: "#FFFFFF",
-      value: 2,
-    },
-    {
-      groupId: 0,
-      rollId: 1,
-      sides: 20,
-      theme: "#FFFFFF",
-      value: 4,
-    },
-  ],
-};
+export const ParameterParseFinalResults = [
+  {
+    groupId: 0,
+    rollId: 0,
+    sides: 20,
+    theme: "#FFFFFF",
+    value: 2,
+  },
+  {
+    groupId: 0,
+    rollId: 1,
+    sides: 20,
+    theme: "#FFFFFF",
+    value: 4,
+  },
+];
 
 export const ReturnParseNotation = [
   {

--- a/src/tests/parseFinalResults.test.js
+++ b/src/tests/parseFinalResults.test.js
@@ -6,17 +6,6 @@ import {
 } from "../mocks";
 
 describe("Given parseFinalResults is called with an array of rolls from Dicebox", () => {
-  it("then calls recursiveSearch", () => {
-    const parser = new ParserInterface();
-    const spy = jest.spyOn(parser, "recursiveSearch");
-
-    parser.parseNotation("2d20"); //TODO: #Issue #1
-    parser.parseFinalResults(ParameterParseFinalResults);
-
-    expect(spy).toHaveBeenCalledTimes(4);
-    expect(spy).toHaveBeenCalledWith(ParameterParseFinalResults, "rolls");
-  });
-
   it("then resets rollsAsFloats", () => {
     const parser = new ParserInterface();
 
@@ -31,7 +20,7 @@ describe("Given parseFinalResults is called with an array of rolls from Dicebox"
 
     parser.updateFloats(ReturnDiceBoxRoll);
     parser.parseNotation("2d20");
-    const result = parser.parseFinalResults({ rolls: ReturnDiceBoxRoll });
+    const result = parser.parseFinalResults(ReturnDiceBoxRoll);
 
     expect(result).toEqual(ReturnParseFinalResults);
   });

--- a/src/tests/recursiveSearch.test.js
+++ b/src/tests/recursiveSearch.test.js
@@ -1,17 +1,9 @@
 //import { ReturnDiceBoxRoll } from "../mocks";
 import ParserInterface from "../ParserInterface";
-import { ParameterParseFinalResults, ReturnRollParserParse } from "../mocks";
+import { ReturnRollParserParse } from "../mocks";
 
 describe("Given parseNotation is called with a roll notation string", () => {
   const parser = new ParserInterface();
-  describe("when recursiveSearch is called with an parseFinalResults object and a search string", () => {
-    const search = parser.recursiveSearch(ParameterParseFinalResults, "rolls");
-
-    it("then returns an array with the key which matches the search string", () => {
-      expect(search).toEqual([ParameterParseFinalResults.rolls]);
-    });
-  });
-
   describe("when recursiveSearch is called with this.parsedNotation object and a search string", () => {
     const callback = jest.fn();
 

--- a/src/tests/updateFloats.test.ts
+++ b/src/tests/updateFloats.test.ts
@@ -3,7 +3,7 @@ import ParserInterface from "../ParserInterface";
 
 describe("when updateFloats is called", () => {
   const parser = new ParserInterface();
-  parser.updateFloats([ReturnDiceBoxRoll]);
+  parser.updateFloats(ReturnDiceBoxRoll);
   it("then updates rollsAsFloats", () => {
     expect(parser.rollsAsFloats).toEqual([0.05, 0.5]);
   });


### PR DESCRIPTION
The parseFinalResults function now just takes a roll result from .roll of Dicebox.